### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/docs/app-architecture.md
+++ b/docs/app-architecture.md
@@ -1,34 +1,34 @@
-#Example App Architecture
+# Example App Architecture
 
 As Pilot concerns itself with the UI & Presenter/Controller layer only it needs to be used as part of a wider app architecture. There is flexibility in this, but an example _Clean_-style architecture is shown below.
 
 The below architecture embodies [Clean Architecture](http://fernandocejas.com/2014/09/03/architecting-android-the-clean-way/) principles, and is similar to the [Viper](http://mutualmobile.github.io/blog/2013/12/04/viper-introduction/) iOS architecture. 
 
-##Overview
+## Overview
 
 ![App Arch with Pilot](/gfx/app_arch.png)
 
-##Layers
+## Layers
 
-###View Layer
+### View Layer
 
 - Plain-Old-Android-Views! These forward input events to and render state from their corresponding Presenter `PilotFrames`.
 - Interacts with Presenter layer by forwarding input-events, and rendering the Presenters `State` object when changed.
 
-###Presenter Layer
+### Presenter Layer
 
 - The PilotStack, which holds mostly Presenter `PilotFrames` with some data only frames. 
 - Presentation Model styles Presenters
 - This layer interacts with the Use-Case layer mostly via asynchronous callbacks. This is preferred over `Observables` at this stage as the returned data may be complicated (i.e could be success with some data, or multiple errors with differnt meta data).
 - Use-case dependencies should be DI'd into the Presenter layer, as opposed to constructor passed, as the `PilotFrames` have fixed constructors.
 
-###Use-Case (Interactor) Layer
+### Use-Case (Interactor) Layer
 
 - Embodies Use-Cases i.e. `Login`, `GetDataX` etc.
 - Interacts with model layer via `Observables` for easy composition inside the Use-Case layer.
 - Model dependencies should be passed via constructor or DI'd to this layer.
 
-###Model Layer
+### Model Layer
 
 - Represents all in-memory-data and all data-sources (i.e. remote API, local DB etc)
 

--- a/docs/example_frame_and_view.md
+++ b/docs/example_frame_and_view.md
@@ -1,4 +1,4 @@
-#ExampleFrame
+# ExampleFrame
 
 ```java
 public class ExamplePresenter extends PilotFrame
@@ -63,7 +63,7 @@ public class ExamplePresenter extends PilotFrame
 }
 ```
     
-#Example View
+# Example View
 
 ```java
 @BackedByFrame(ExamplePresenter.class)

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -1,6 +1,6 @@
-#F.A.Q.
+# F.A.Q.
 
-##Q. Is this a `FragmentManager` for `Views?`
+## Q. Is this a `FragmentManager` for `Views?`
 
 At first glance this may look like a `FragmentManager` for `Views`, but this would be misleading.
 
@@ -14,12 +14,12 @@ This issue has led to an explosion of MVP libraries and approaches to try and mo
 
 Pilot is also **Presenter-aware**, has plumbing to handle `View` creation and **Presenter mapping** out of the box (which is optional and can be used to trigger Fragment/Activity/Dialog creation also), **survives config-changes and process-death** and has a **queryable** app stack **which can hold scoped data** as well as view-backing-presenters. 
 
-##Q. How can I use this as part of a wider architecture?
+## Q. How can I use this as part of a wider architecture?
 
 See [Example App Architecture](https://github.com/doridori/Pilot/blob/master/docs/app-architecture.md)
 
 
-##Q. So where does one put context related android and google play services code in this architecture?
+## Q. So where does one put context related android and google play services code in this architecture?
 
 If your interacting with any system service or something that requires an application context it would make sense to apply some form of DI to make this object available to your consumers anyway. If you had a frame in the stack that represented grabbing a location and doing something with it this could be done via your DId location obtainer.
 

--- a/docs/general_concepts.md
+++ b/docs/general_concepts.md
@@ -1,12 +1,12 @@
-#General Concepts
+# General Concepts
 
-##Single-Activity Application
+## Single-Activity Application
 
 I find a lot of the applications I have build in the last couple of years sit inside a single `Activity` and just manipulate `Fragments` and/or `View`. You can use a single `Activity` which holds a single `PilotStack` for the simplest use case. This however does not mean you cant jump out to seperate activitys, for example when integrating with 3rd party libs which require this.
 
 Advantage: Simple
 
-##Frame-to-Frame control flow
+## Frame-to-Frame control flow
 
 As mentioned in the `Motivations` post above this kind of control flow (which bypasses `android.*` classes completly has its advantages) and is made very simple with Pilot. An example below
 
@@ -23,7 +23,7 @@ public class FirstViewFrame extends PilotFrame
 
 Advantage: This means for each and quick JVM testing and any interested renderer could just listen out for `PilotStack` changes and work out how to render them. You could imagine it would be trivial to replace the whole interface on an application with a command line and you would not have to change a line of controller logic (ok so you may never do this but it highlights a good degree of decoupling!).
 
-##Presenter lifecycle management
+## Presenter lifecycle management
 
 As is the root goal of most frameworks that interact with controller lifecycle management is an important point. Using the 'PilotStack' the 'PilotFrames' (and therefore any controllers they may be composed of and provide) live just as long as they need to without worrying about config-changes _or_ the lifecycle of any attached view/activity component. This happens for **free** as all app navigation happens via the `PilotStack` in the first place. For example see below
 
@@ -31,25 +31,25 @@ As is the root goal of most frameworks that interact with controller lifecycle m
 
 This may seem overly simple - but in my mind thats a good thing! There are many approaches to this singular issue that can easily get over-complicated when controllers and liveness are tied too much into an Activity or view components particular lifecycle.
 
-##How Presenters are attached to Views and displayed.
+## How Presenters are attached to Views and displayed.
 
 //todo
 
-###What about after a config-change?
+### What about after a config-change?
 
 After a config-change the PilotStack has been preserved via the Activity lifecycle delegate methods - which will auto show the view at the top of the PilotStack. 
 
-###What about re-inflated Views that are now presenter-less?
+### What about re-inflated Views that are now presenter-less?
 
 These will either have their Presenter pushed back to them or will be removed if they represent a PilotFrame that is not longer top of the PilotStack. You would probably only encounter this case in you were using a PilotStack inside a `Fragment` that had been re-infalted. Not the recommended use-case anyhow.
 
-###What about child views that also have Presenters?!
+### What about child views that also have Presenters?!
 
 There are many forms these can take but a simple way to handle these are to maintain a collection of child-Presenter objects inside the PilotFrame and push / pull them out depending on their own individual lifecycle. 
 
 For example you may have a RecyclerView which contains child Views which are each backed by their own Presenter. These could be pulled from the main PilotFrame backed Presenter by some meta data i.e. id.
 
-##Scoped Data
+## Scoped Data
 
 This is an interesting one. As mentioned in the `Motivations` post linked above, scoped data will make people think of differnt implementations depending on if any DI frameworks (think Dagger) are in use. I will restate here that this solution is not to replace Dagger (and also does not require it) but is a way of (optionally) handling data scopes (and the method by which the scoped data could be added and removed from any DI frameworks at runtime).
 
@@ -79,19 +79,19 @@ public class SecondPilotFrame extends PilotFrame
 
 This has benefits of scoped data being able to handle its own lifecycle and also being cleared by default when the stack is cleared but also if clearing the stack on `Activity.finish()` you get all your sensitive data cleaned up for free. Happy days.
 
-##Controller Lifecycle Events
+## Controller Lifecycle Events
 
 See [Issue](https://github.com/doridori/Pilot/issues/7) representing this task.
 
-##onFrameResult
+## onFrameResult
 
 //todo
 
-##Handling Process Death
+## Handling Process Death
 
 //todo
 
-##Opaqueness 
+## Opaqueness 
 
 A frame can represent a View that is opaque or partially transparent. This infomation is stored obtained via a `UITypeHandlers.isOpaque()` method (see [#20](https://github.com/doridori/Pilot/issues/20)). This information is important as it allows UITypeHanders to rebuild the entire visible UI at any point.
 

--- a/docs/quick_start.md
+++ b/docs/quick_start.md
@@ -1,8 +1,8 @@
-#Quick Start
+# Quick Start
 
 Have a quick look at [Example Frame & View](https://github.com/doridori/Pilot/blob/master/docs%2Fexample_frame_and_view.md) and then see below for how to implement with Pilot.
     
-##Create some `PilotFrame` subclasses
+## Create some `PilotFrame` subclasses
 
 These represent the **app states** (think _LoginScreen_ or _ContentScreen_) and the **data-scopes** (think _session_ or _domain-driven-process_)  of your application and are the things that will live on the stack.
 
@@ -14,7 +14,7 @@ As mentioned elsewhere there is no actual rule for how your `PilotFrame` classes
 
 For an example check out [Example Frame & View](https://github.com/doridori/Pilot/blob/master/docs%2Fexample_frame_and_view.md).
 
-##`View` should reflect state of corresponding `PilotFrame`
+## `View` should reflect state of corresponding `PilotFrame`
 
 When a `PilotFrameLayout` extending `View` is created is will have the corresponding `PilotFrame` passed to it. This is availble by the time `View.onAttachedToWindow()` is called. View subclasses can override `backingFrameSet(ShowPadPresenter backingPilotFrame)` to do any post-backing frame set initialisation.
 
@@ -22,7 +22,7 @@ State-change listeners are added inside the `PilotFrame` `View.onAttached` and `
 
 For an example check out [Example Frame & View](https://github.com/doridori/Pilot/blob/master/docs%2Fexample_frame_and_view.md).
 
-##Declare what _Top Level Views_ exist in the application
+## Declare what _Top Level Views_ exist in the application
 
 Each main view/screen of the application will be represented by a `PilotFrame` subclass, which will hold that screens ViewState and communicate with any asynchronous code. Each of these `PilotState`s need to have a corresponding `View` class that will represent it. In this documentation I am referring to these as _Top Level Views_ (TLV). These can to be declared as so: 
 
@@ -38,7 +38,7 @@ static final Class<? extends PilotFrameBackedFrameLayout>[] TOP_LEVEL_VIEWS = ne
 
 Each of these TLVs are matched to a `PilotFrame` subclass via a `@BackedByFrame` annotation declared in the TLV - more on this in a bit.
 
-##Declare a `PilotUISyncer` for these TLVs
+## Declare a `PilotUISyncer` for these TLVs
  
 A `PilotUISyncer` is the class that is responsible for ensuring the UI matches the current `PilotStack` state. 
 
@@ -57,7 +57,7 @@ private PilotUISyncer buildPilotSyncer(FrameLayout rootView)
 }
 ```
 
-##Integrate `PilotLifecycleManager` into your `Activity`
+## Integrate `PilotLifecycleManager` into your `Activity`
 
 //TODO Navi component
 
@@ -124,6 +124,6 @@ Then **delegate** a few `Activity` lifecycle calls to the `PilotLifecycleManager
 
 Note inside `onCreate` we pass the `PilotSyncer` we declared earlier.
 
-##Launch your app
+## Launch your app
 
 Following the above on app launch your initial PilotFrame should be pushed on the `PilotStack` and your `PilotSyncer` registered `UIViewTypeHandler` should create and display the corresponding `View`, Voila!


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
